### PR TITLE
Initialize omni-arb skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test format
+
+test:
+	pytest -q
+
+format:
+	black .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# GodX
+# Omni-Arb
+
+Omni-Arb is a lightweight skeleton for a deterministic arbitrage and directional
+trading research platform. It demonstrates an end-to-end flow from opportunity
+intake through risk checks, execution and logging.
+
+## Layout
+
+- `core/` – trading primitives
+- `orchestrator/` – pipeline wiring modules together
+- `nlp/` – placeholders for FinGPT/FinRAG integrations
+- `research/` – backtesting utilities
+- `deploy/` – docker-compose and infra helpers
+- `config/` – configuration files
+- `tests/` – pytest test suite
+
+## Getting Started
+
+```bash
+make test
+```

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,13 @@
+# Runbook
+
+## Local Development
+
+1. Install dependencies (e.g. `pip install -r requirements.txt` if present).
+2. Run tests with `make test`.
+3. Use `docker-compose` from `deploy/` to spin up infra services.
+
+## Deployment
+
+- Ensure environment variables for API keys are set (.env).
+- `docker-compose up -d` will start app, Redis, PostgreSQL, Prometheus and Grafana.
+- Logs are JSON formatted via structlog and can be scraped by Prometheus.

--- a/config/exchanges.yml
+++ b/config/exchanges.yml
@@ -1,0 +1,3 @@
+binance:
+  api_key: "${BINANCE_API_KEY}"
+  api_secret: "${BINANCE_API_SECRET}"

--- a/config/risk.yml
+++ b/config/risk.yml
@@ -1,0 +1,2 @@
+max_position: 10
+max_notional: 100000

--- a/config/symbols.yml
+++ b/config/symbols.yml
@@ -1,0 +1,2 @@
+- BTCUSDT
+- ETHUSDT

--- a/config/thresholds.yml
+++ b/config/thresholds.yml
@@ -1,0 +1,2 @@
+latency_ms_p95: 900
+error_rate: 0.005

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core trading modules for Omni-Arb."""

--- a/core/data/__init__.py
+++ b/core/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data logging utilities."""

--- a/core/data/logger.py
+++ b/core/data/logger.py
@@ -1,0 +1,12 @@
+import logging
+import json
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps({"level": record.levelname, "msg": record.getMessage()})
+
+handler = logging.StreamHandler()
+handler.setFormatter(JSONFormatter())
+logger = logging.getLogger("omni")
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)

--- a/core/exchange/__init__.py
+++ b/core/exchange/__init__.py
@@ -1,0 +1,1 @@
+"""Exchange interfaces."""

--- a/core/exchange/base.py
+++ b/core/exchange/base.py
@@ -1,0 +1,9 @@
+import abc
+
+class Exchange(metaclass=abc.ABCMeta):
+    """Abstract exchange interface."""
+
+    @abc.abstractmethod
+    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        """Place an order and return execution details."""
+        raise NotImplementedError

--- a/core/execution/__init__.py
+++ b/core/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Order execution components."""

--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,0 +1,12 @@
+from core.exchange.base import Exchange
+from core.data.logger import logger
+
+class Executor:
+    """Simple trade executor."""
+
+    def __init__(self, exchange: Exchange):
+        self.exchange = exchange
+
+    def execute(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        logger.info(f"execute_order symbol={symbol} side={side} qty={quantity} price={price}")
+        return self.exchange.place_order(symbol, side, quantity, price)

--- a/core/risk/__init__.py
+++ b/core/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk management helpers."""

--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -1,0 +1,6 @@
+class RiskManager:
+    """Very small placeholder risk manager."""
+
+    def check(self, opportunity: dict) -> bool:
+        """Approve trade if quantity is positive."""
+        return opportunity.get("qty", 0) > 0

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  app:
+    build: ..
+    environment:
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      - redis
+      - db
+  redis:
+    image: redis:7
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_PASSWORD: example
+  prometheus:
+    image: prom/prometheus
+  grafana:
+    image: grafana/grafana

--- a/nlp/__init__.py
+++ b/nlp/__init__.py
@@ -1,0 +1,1 @@
+"""NLP modules."""

--- a/nlp/rag.py
+++ b/nlp/rag.py
@@ -1,0 +1,4 @@
+"""Placeholders for FinGPT/FinRAG integrations."""
+
+def analyze(text: str) -> str:
+    return f"analysis: {text[:20]}"

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""Agent orchestration pipeline."""

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,0 +1,17 @@
+from core.risk.manager import RiskManager
+from core.execution.executor import Executor
+from core.exchange.base import Exchange
+
+class Pipeline:
+    """End-to-end trading pipeline."""
+
+    def __init__(self, exchange: Exchange):
+        self.risk = RiskManager()
+        self.executor = Executor(exchange)
+
+    def run(self, opportunity: dict):
+        if not self.risk.check(opportunity):
+            return {"status": "rejected"}
+        return self.executor.execute(
+            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
+        )

--- a/research/__init__.py
+++ b/research/__init__.py
@@ -1,0 +1,1 @@
+"""Research and backtesting utilities."""

--- a/research/backtest.py
+++ b/research/backtest.py
@@ -1,0 +1,4 @@
+"""Simple backtest placeholder."""
+
+def run():
+    return {"pnl": 0}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,19 @@
+from orchestrator.pipeline import Pipeline
+from core.exchange.base import Exchange
+
+
+class DummyExchange(Exchange):
+    def __init__(self):
+        self.orders = []
+
+    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append((symbol, side, quantity, price))
+        return {"status": "filled"}
+
+
+def test_pipeline_executes_order():
+    exchange = DummyExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    assert result["status"] == "filled"
+    assert exchange.orders[0][0] == "BTCUSDT"


### PR DESCRIPTION
## Summary
- scaffold omni-arb project structure with core trading modules, orchestrator pipeline, and config files
- add docker-compose, runbook, and Makefile with test target
- provide basic test ensuring pipeline executes trade via dummy exchange
- add package docstrings to initialization modules

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc93d65f8832c9f0e7d2f44fe39eb