### PR TITLE
Add extended docker-compose infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ intake through risk checks, execution and logging.
 ```bash
 make test
 ```
+
+## Infrastructure
+
+Start the supporting services with Docker Compose:
+
+```bash
+cd deploy
+docker-compose up -d
+```
+
+This launches Redis, PostgreSQL, ClickHouse, Prometheus, and Grafana.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -4,10 +4,10 @@
 
 1. Install dependencies (e.g. `pip install -r requirements.txt` if present).
 2. Run tests with `make test`.
-3. Use `docker-compose` from `deploy/` to spin up infra services.
+3. Use `docker-compose` from `deploy/` to spin up Redis, PostgreSQL, ClickHouse, Prometheus, and Grafana.
 
 ## Deployment
 
 - Ensure environment variables for API keys are set (.env).
-- `docker-compose up -d` will start app, Redis, PostgreSQL, Prometheus and Grafana.
+- `docker-compose up -d` will start Redis, PostgreSQL, ClickHouse, Prometheus and Grafana.
 - Logs are JSON formatted via structlog and can be scraped by Prometheus.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,19 +1,30 @@
-version: '3.8'
+version: "3.9"
 services:
-  app:
-    build: ..
-    environment:
-      - PYTHONUNBUFFERED=1
-    depends_on:
-      - redis
-      - db
   redis:
     image: redis:7
-  db:
-    image: postgres:14
+    command: ["redis-server","--appendonly","yes"]
+    ports:
+      - "6379:6379"
+  postgres:
+    image: postgres:15
     environment:
-      POSTGRES_PASSWORD: example
+      POSTGRES_PASSWORD: omni
+      POSTGRES_USER: omni
+      POSTGRES_DB: omni
+    ports:
+      - "5432:5432"
+  clickhouse:
+    image: clickhouse/clickhouse-server:24
+    ports:
+      - "9000:9000"
+      - "8123:8123"
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus:/etc/prometheus
+    ports:
+      - "9090:9090"
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- replace docker-compose with Redis, Postgres, ClickHouse, Prometheus, and Grafana services
- add Prometheus config directory
- document how to start infrastructure

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d0461b5cc832c88c767ac7205b791