### PR TITLE
Configure Prometheus targets and alerting

### DIFF
--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: data-feed
+    rules:
+      - alert: DataFeedStale
+        expr: time() - omni_data_feed_last_update_timestamp_seconds > 300
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Data feed stale
+          description: Data feed has not been updated in the last 5 minutes.

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - alerts.yml
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']
+  - job_name: 'omni-app'
+    static_configs:
+      - targets: ['api:8080']
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis:9121']


### PR DESCRIPTION
## Summary
- add Prometheus configuration with scrape jobs for core services and rule file reference
- define DataFeedStale alert to monitor data feed freshness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1855d0f0832c88e1c6c15226c03a