### PR TITLE
feat: add api service with prometheus metrics

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y curl \ 
+    && rm -rf /var/lib/apt/lists/* \ 
+    && pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+app = FastAPI()
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+prometheus-client

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,14 @@
 version: "3.9"
 services:
+  api:
+    build: ../api
+    ports: ["8080:8080"]
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
   redis:
     image: redis:7
     command: ["redis-server","--appendonly","yes"]

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'omni-app'
+    static_configs:
+      - targets: ['api:8080']


### PR DESCRIPTION
## Summary
- serve FastAPI app exposing `/metrics`
- add API service with healthcheck to docker-compose
- configure Prometheus scrape job for the API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d17c1080c832ca6836e8003362b55