### PR TITLE
Add Grafana Prometheus datasource configuration

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -20,4 +20,5 @@ services:
     ports: ["9090:9090"]
   grafana:
     image: grafana/grafana:latest
+    volumes: ["./grafana/provisioning:/etc/grafana/provisioning"]
     ports: ["3000:3000"]

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,6 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
## Summary
- provision Grafana Prometheus datasource via new configuration
- mount Grafana provisioning directory in docker-compose

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d185aac6c832c866d0df8ca228bbc