### PR TITLE
Add quick infra health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ intake through risk checks, execution and logging.
 - `deploy/` – docker-compose and infra helpers
 - `config/` – configuration files
 - `tests/` – pytest test suite
+## Infrastructure
+
+After bringing up services with `docker-compose up -d` (see `RUNBOOK.md`), you can verify Prometheus and the app are healthy:
+
+```bash
+curl -s http://localhost:9090/-/healthy
+curl -s http://localhost:3000/login
+```
 
 ## Getting Started
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -10,4 +10,10 @@
 
 - Ensure environment variables for API keys are set (.env).
 - `docker-compose up -d` will start app, Redis, PostgreSQL, Prometheus and Grafana.
+
+```bash
+curl -s http://localhost:9090/-/healthy
+curl -s http://localhost:3000/login
+```
+
 - Logs are JSON formatted via structlog and can be scraped by Prometheus.


### PR DESCRIPTION
## Summary
- document simple health check curls for Prometheus and the app
- expose same quick checks in README infrastructure section

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d1864d7a0832c8c41276a48a009cb