### PR TITLE
Add Pushgateway metric scripts and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PY := python3
 PIP := pip
 DC := docker compose
 APP := omni-arb
+PGW := localhost:9091
 
 # ===== Default =====
 .PHONY: help
@@ -41,19 +42,19 @@ logs:
 # ===== App Entrypoints (dummy) =====
 .PHONY: logger
 logger:
-	. .venv/bin/activate && $(PY) apps/ingest/logger.py
+        . .venv/bin/activate && PUSHGATEWAY_URL=$(PGW) $(PY) apps/ingest/logger.py
 
 .PHONY: orchestrator
 orchestrator:
-	. .venv/bin/activate && $(PY) apps/executor/orchestrator.py
+        . .venv/bin/activate && PUSHGATEWAY_URL=$(PGW) $(PY) apps/executor/orchestrator.py
 
 .PHONY: backtest
 backtest:
-	. .venv/bin/activate && $(PY) apps/backtester/run_backtest.py
+        . .venv/bin/activate && PUSHGATEWAY_URL=$(PGW) $(PY) apps/backtester/run_backtest.py
 
 .PHONY: train-ppo
 train-ppo:
-	. .venv/bin/activate && $(PY) apps/research/train_ppo.py --symbol BTCUSDT --epochs 10
+        . .venv/bin/activate && PUSHGATEWAY_URL=$(PGW) $(PY) apps/research/train_ppo.py --symbol BTCUSDT --epochs 10
 
 .PHONY: test
 test:

--- a/apps/backtester/run_backtest.py
+++ b/apps/backtester/run_backtest.py
@@ -1,0 +1,18 @@
+import os
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+PUSHGATEWAY = os.getenv("PUSHGATEWAY_URL", "localhost:9091")
+
+
+def main() -> None:
+    registry = CollectorRegistry()
+    gauge = Gauge("backtest_runs", "Dummy backtest run", registry=registry)
+    gauge.set(1)
+    try:
+        push_to_gateway(PUSHGATEWAY, job="backtest", registry=registry)
+    except Exception as exc:  # pragma: no cover - network issues are non-critical
+        print(f"Pushgateway unreachable: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/executor/orchestrator.py
+++ b/apps/executor/orchestrator.py
@@ -1,0 +1,18 @@
+import os
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+PUSHGATEWAY = os.getenv("PUSHGATEWAY_URL", "localhost:9091")
+
+
+def main() -> None:
+    registry = CollectorRegistry()
+    gauge = Gauge("orchestrator_runs", "Dummy orchestrator run", registry=registry)
+    gauge.set(1)
+    try:
+        push_to_gateway(PUSHGATEWAY, job="orchestrator", registry=registry)
+    except Exception as exc:  # pragma: no cover - network issues are non-critical
+        print(f"Pushgateway unreachable: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ingest/logger.py
+++ b/apps/ingest/logger.py
@@ -1,0 +1,18 @@
+import os
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+PUSHGATEWAY = os.getenv("PUSHGATEWAY_URL", "localhost:9091")
+
+
+def main() -> None:
+    registry = CollectorRegistry()
+    gauge = Gauge("logger_runs", "Dummy logger run", registry=registry)
+    gauge.set(1)
+    try:
+        push_to_gateway(PUSHGATEWAY, job="logger", registry=registry)
+    except Exception as exc:  # pragma: no cover - network issues are non-critical
+        print(f"Pushgateway unreachable: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/research/train_ppo.py
+++ b/apps/research/train_ppo.py
@@ -1,0 +1,24 @@
+import argparse
+import os
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+PUSHGATEWAY = os.getenv("PUSHGATEWAY_URL", "localhost:9091")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--epochs", type=int, default=10)
+    args = parser.parse_args()
+
+    registry = CollectorRegistry()
+    gauge = Gauge("train_ppo_epochs", "Number of training epochs", registry=registry)
+    gauge.set(args.epochs)
+    try:
+        push_to_gateway(PUSHGATEWAY, job="train_ppo", registry=registry)
+    except Exception as exc:  # pragma: no cover - network issues are non-critical
+        print(f"Pushgateway unreachable: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+prometheus-client


### PR DESCRIPTION
## Summary
- Add logger, orchestrator, backtest, and train_ppo scripts under apps/ that push dummy metrics to a Prometheus Pushgateway
- Update Makefile to use new apps/ paths and pass PUSHGATEWAY_URL to each target
- Add requirements.txt with prometheus-client dependency

## Testing
- `python apps/ingest/logger.py`
- `python apps/executor/orchestrator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d210939ec832c9952e24dcf2cb193