### PR TITLE
Add executor orchestrator metrics script

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application entrypoints."""

--- a/apps/executor/__init__.py
+++ b/apps/executor/__init__.py
@@ -1,0 +1,1 @@
+"""Executor service."""

--- a/apps/executor/orchestrator.py
+++ b/apps/executor/orchestrator.py
@@ -1,0 +1,29 @@
+"""Simple orchestrator emitting metrics."""
+
+import random
+import time
+
+from metrics import reg, counters, hists, push
+
+
+# Register metrics
+reg("events", kind="counter", description="Number of executor events", labels=["type"])
+reg("errors", kind="counter", description="Number of executor errors")
+reg("leg_latency", kind="histogram", description="Latency per leg in milliseconds")
+
+
+def main() -> None:
+    """Emit metrics for five trade attempts."""
+    for _ in range(5):
+        leg_latency = random.randint(80, 600)
+        hists["leg_latency"].observe(leg_latency)
+        counters["events"].labels("trade_attempt").inc()
+        if random.random() < 0.05:
+            counters["errors"].inc()
+        push()
+        time.sleep(1)
+    print("orchestrator: metrics pushed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add executor orchestrator emitting metrics via reg, counters, hists, and push
- initialize apps package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d210a3b08832cac2cfec6ed7b2fd4