### PR TITLE
feat: add ingest metrics logger

### DIFF
--- a/apps/ingest/logger.py
+++ b/apps/ingest/logger.py
@@ -1,0 +1,18 @@
+import random
+import time
+
+from metrics import reg, counters, gauges, push
+
+
+def main() -> None:
+    reg("ingest")
+    for _ in range(3):
+        counters("events", "quote_batch")
+        gauges("lag_ms", random.randint(20, 200))
+        push()
+        time.sleep(1)
+    print("logger: metrics pushed")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/ingest/metrics.py
+++ b/apps/ingest/metrics.py
@@ -1,0 +1,25 @@
+import collections
+
+COUNTERS = collections.defaultdict(int)
+GAUGES = {}
+
+
+def reg(name: str) -> None:
+    """Register a metrics namespace (no-op for stub)."""
+    return None
+
+
+def counters(metric: str, typ: str) -> None:
+    """Increment counter identified by metric and type."""
+    key = (metric, typ)
+    COUNTERS[key] += 1
+
+
+def gauges(metric: str, value: int) -> None:
+    """Set gauge value for metric."""
+    GAUGES[metric] = value
+
+
+def push() -> None:
+    """Push metrics to backend (stub)."""
+    return None


### PR DESCRIPTION
## Summary
- add ingestion logger that tracks events counter and lag gauge
- stub metrics utilities for counters, gauges, registry, and push

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d210b4cac832cb82045e286282495