### PR TITLE
Update Prometheus scrape interval and add API and Pushgateway jobs

### DIFF
--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,9 +1,8 @@
 global:
-  scrape_interval: 15s
+  scrape_interval: 5s
   evaluation_interval: 15s
 
-rule_files:
-  - alerts.yml
+rule_files: ["alerts.yml"]
 
 scrape_configs:
   - job_name: 'prometheus'
@@ -15,3 +14,10 @@ scrape_configs:
   - job_name: 'redis'
     static_configs:
       - targets: ['redis:9121']
+  - job_name: 'api'
+    static_configs:
+      - targets: ['api:8000']
+  - job_name: 'pushgateway'
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']


### PR DESCRIPTION
## Summary
- reduce Prometheus scrape interval to 5s
- add API and Pushgateway scrape jobs
- ensure alerts rule file is included

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d210f7c44832c86c9448ff8c9244c