### PR TITLE
Add Pushgateway service and adjust Prometheus volume

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,8 +16,14 @@ services:
     ports: ["9000:9000","8123:8123"]
   prometheus:
     image: prom/prometheus:latest
-    volumes: ["./prometheus:/etc/prometheus"]
+    volumes: ["./deploy/prometheus:/etc/prometheus"]
     ports: ["9090:9090"]
+  pushgateway:
+    image: prom/pushgateway:latest
+    ports: ["9091:9091"]
+    networks: [omni_net]
   grafana:
     image: grafana/grafana:latest
     ports: ["3000:3000"]
+networks:
+  omni_net:


### PR DESCRIPTION
## Summary
- mount Prometheus configuration from `./deploy/prometheus`
- add Pushgateway service on port 9091 and attach to `omni_net`
- declare `omni_net` network

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d211092fc832cb6832c26144d406c