### PR TITLE
Expose Prometheus metrics endpoint for API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, Request, Response
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+import time
+
+APP_NAME = "omni-app"
+
+request_counter = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["app_name", "method", "endpoint", "http_status"],
+)
+request_latency = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency in seconds",
+    ["app_name", "endpoint"],
+)
+
+app = FastAPI()
+
+@app.middleware("http")
+async def prometheus_middleware(request: Request, call_next):
+    start_time = time.time()
+    response = await call_next(request)
+    duration = time.time() - start_time
+    request_counter.labels(APP_NAME, request.method, request.url.path, response.status_code).inc()
+    request_latency.labels(APP_NAME, request.url.path).observe(duration)
+    return response
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+@app.get("/")
+async def read_root():
+    return {"status": "ok"}
+

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
       - targets: ['prometheus:9090']
   - job_name: 'omni-app'
     static_configs:
-      - targets: ['api:8080']
+      - targets: ['api:8000']
   - job_name: 'redis'
     static_configs:
       - targets: ['redis:9121']


### PR DESCRIPTION
## Summary
- add FastAPI app with Prometheus metrics middleware
- update Prometheus scrape config to target `api:8000`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2114849c832c8c1f440cb72947c4