### PR TITLE
feat: expose prometheus metrics endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+# API package

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI, Response, Request
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+
+app = FastAPI()
+
+REQUEST_COUNT = Counter(
+    "request_count", "Total request count", ["method", "endpoint", "http_status"]
+)
+
+
+@app.middleware("http")
+async def count_requests(request: Request, call_next):
+    response = await call_next(request)
+    REQUEST_COUNT.labels(request.method, request.url.path, response.status_code).inc()
+    return response
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/")
+def read_root():
+    return {"status": "ok"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+prometheus-client
+uvicorn
+httpx

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
       - targets: ['prometheus:9090']
   - job_name: 'omni-app'
     static_configs:
-      - targets: ['api:8080']
+      - targets: ['api:8000']
   - job_name: 'redis'
     static_configs:
       - targets: ['redis:9121']

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def test_metrics_endpoint_exposes_prometheus_metrics():
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "python_info" in response.text


### PR DESCRIPTION
## Summary
- add FastAPI service with Prometheus /metrics endpoint
- configure Prometheus to scrape api:8000
- cover metrics endpoint with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d230a4c00832ca733b28b0a93e725