### PR TITLE
Add ingest metrics logger script

### DIFF
--- a/apps/ingest/logger.py
+++ b/apps/ingest/logger.py
@@ -1,0 +1,29 @@
+import random
+import time
+
+try:
+    from metrics import reg, counters, gauges, push
+except ImportError:  # Fallback stubs if metrics package is unavailable
+    def reg(*args, **kwargs):
+        pass
+
+    def counters(name: str, labels: dict | None = None, value: int = 1):
+        labels = labels or {}
+        print(f"counter {name} {labels} += {value}")
+
+    def gauges(name: str, value: float):
+        print(f"gauge {name} = {value}")
+
+    def push():
+        print("metrics pushed")
+
+
+reg("logger")
+
+for _ in range(3):
+    counters("events", {"type": "quote_batch"})
+    gauges("lag_ms", random.randint(20, 200))
+    push()
+    time.sleep(1)
+
+print("logger: metrics pushed")


### PR DESCRIPTION
## Summary
- add logger script that records events and lag metrics
- push metrics after three iterations

## Testing
- `pytest -q`
- `python apps/ingest/logger.py`

------
https://chatgpt.com/codex/tasks/task_e_689d230e72f8832cbd2e7642ea24def4