### PR TITLE
Add Pushgateway service and mount Prometheus config

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,8 +16,15 @@ services:
     ports: ["9000:9000","8123:8123"]
   prometheus:
     image: prom/prometheus:latest
-    volumes: ["./prometheus:/etc/prometheus"]
+    volumes: ["./deploy/prometheus:/etc/prometheus"]
     ports: ["9090:9090"]
+  pushgateway:
+    image: prom/pushgateway:latest
+    ports: ["9091:9091"]
+    networks: ["default","omni_net"]
   grafana:
     image: grafana/grafana:latest
     ports: ["3000:3000"]
+networks:
+  omni_net:
+    external: true


### PR DESCRIPTION
## Summary
- add Pushgateway service to docker-compose with port 9091 and omni_net network
- mount Prometheus configuration from ./deploy/prometheus
- define external omni_net network

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d2312d28c832cb9f9f08e68512378