### PR TITLE
Add execute alias to pipeline

### DIFF
--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -15,3 +15,7 @@ class Pipeline:
         return self.executor.execute(
             opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
         )
+
+    # Backwards compatibility for tests expecting an `execute` method
+    def execute(self, opportunity: dict):
+        return self.run(opportunity)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,6 +14,6 @@ class DummyExchange(Exchange):
 def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
-    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    result = pipe.execute({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
     assert result["status"] == "filled"
     assert exchange.orders[0][0] == "BTCUSDT"


### PR DESCRIPTION
## Summary
- add `execute` alias to `Pipeline` for backward compatibility
- adjust pipeline tests to use the new alias

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d316d6a50832ca54fff63891f9fd8