### PR TITLE
Add market environment and PPO training stub

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application entrypoints."""

--- a/apps/research/__init__.py
+++ b/apps/research/__init__.py
@@ -1,0 +1,1 @@
+"""Research scripts."""

--- a/apps/research/train_ppo.py
+++ b/apps/research/train_ppo.py
@@ -1,0 +1,33 @@
+"""Placeholder PPO training script."""
+
+import argparse
+import pandas as pd
+
+from finrl_meta.envs.market_env import make_env
+
+
+def train(symbol: str, epochs: int) -> None:
+    """Instantiate the market environment and run a dummy training loop."""
+    # In practice the dataframe would be loaded with historical data.
+    df = pd.DataFrame()
+    env = make_env(df, {"features": ["close"], "lookback": 10, "fee": 0.001, "slippage": 0.001})
+
+    for _ in range(epochs):
+        env.reset()
+        done = False
+        while not done:
+            # Random policy for placeholder purposes
+            action = env.action_space.sample()
+            _, _, done, _ = env.step(action)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--symbol", required=True)
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args()
+    train(args.symbol, args.epochs)
+
+
+if __name__ == "__main__":
+    main()

--- a/finrl_meta/envs/market_env.py
+++ b/finrl_meta/envs/market_env.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pandas as pd
+import gym
+from gym import spaces
+
+
+class MarketEnv(gym.Env):
+    """A minimal market environment following the Gym API.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Time-indexed market data.
+    cfg : dict
+        Environment configuration with keys:
+            - features: list of column names used as observations
+            - lookback: number of timesteps in each observation window
+            - fee: trading fee proportion per transaction
+            - slippage: slippage proportion per transaction
+    """
+
+    metadata = {"render.modes": []}
+
+    def __init__(self, df: pd.DataFrame, cfg: dict):
+        super().__init__()
+        self.df = df.reset_index(drop=True)
+        self.features = cfg.get("features", ["close"])
+        self.lookback = int(cfg.get("lookback", 1))
+        self.fee = float(cfg.get("fee", 0.0))
+        self.slippage = float(cfg.get("slippage", 0.0))
+
+        obs_shape = (self.lookback * len(self.features),)
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=obs_shape, dtype=np.float32
+        )
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+
+        self.current_step = self.lookback
+        self.position = 0.0
+        self.pnl_history: list[float] = []
+
+    # ------------------------------------------------------------------
+    def reset(self):  # type: ignore[override]
+        self.current_step = self.lookback
+        self.position = 0.0
+        self.pnl_history.clear()
+        return self._get_observation()
+
+    # ------------------------------------------------------------------
+    def step(self, action):  # type: ignore[override]
+        action = float(np.clip(action, -1.0, 1.0))
+        prev_price = self.df["close"].iloc[self.current_step - 1]
+        price = self.df["close"].iloc[self.current_step]
+
+        prev_pos = self.position
+        self.position = action
+        trade = self.position - prev_pos
+
+        fee_cost = abs(trade) * self.fee * price
+        slip_cost = abs(trade) * self.slippage * price
+
+        pnl = (price - prev_price) * prev_pos - fee_cost - slip_cost
+        self.pnl_history.append(pnl)
+        risk = np.std(self.pnl_history[-self.lookback :]) if len(self.pnl_history) > 1 else 0.0
+        reward = pnl / (risk + 1e-8)
+
+        self.current_step += 1
+        done = self.current_step >= len(self.df)
+        obs = self._get_observation() if not done else np.zeros(self.observation_space.shape, dtype=np.float32)
+        info = {"pnl": pnl, "position": self.position}
+        return obs, reward, done, info
+
+    # ------------------------------------------------------------------
+    def _get_observation(self) -> np.ndarray:
+        window = self.df[self.features].iloc[
+            self.current_step - self.lookback : self.current_step
+        ]
+        return window.values.flatten().astype(np.float32)
+
+
+# ----------------------------------------------------------------------
+def make_env(df: pd.DataFrame, cfg: dict) -> MarketEnv:
+    """Factory function returning a MarketEnv instance."""
+    return MarketEnv(df, cfg)


### PR DESCRIPTION
## Summary
- add gym-based `MarketEnv` supporting configurable features, lookback window and costs
- expose `make_env` factory and wire into new PPO training script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689db3fb69e4832cba9666f422e0aa9c