### PR TITLE
feat: add ExecResult and latency-aware IOC execution

### DIFF
--- a/core/exchange/base.py
+++ b/core/exchange/base.py
@@ -7,3 +7,10 @@ class Exchange(metaclass=abc.ABCMeta):
     def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
         """Place an order and return execution details."""
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def place_order_ioc(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        """Place an immediate-or-cancel order."""
+        raise NotImplementedError

--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,12 +1,57 @@
+import time
 from core.exchange.base import Exchange
 from core.data.logger import logger
+from core.execution.types import ExecResult
+
 
 class Executor:
-    """Simple trade executor."""
+    """Trade executor handling two-leg strategies."""
 
-    def __init__(self, exchange: Exchange):
+    def __init__(self, exchange: Exchange, max_latency_ms: int = 1000):
         self.exchange = exchange
+        self.max_latency_ms = max_latency_ms
 
-    def execute(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
-        logger.info(f"execute_order symbol={symbol} side={side} qty={quantity} price={price}")
-        return self.exchange.place_order(symbol, side, quantity, price)
+    def execute_pair(self, leg1: dict, leg2: dict) -> ExecResult:
+        details = {"latency_ms": {}, "responses": {}, "max_latency_ms": self.max_latency_ms}
+        # First leg
+        try:
+            start = time.perf_counter()
+            resp1 = self.exchange.place_order_ioc(
+                leg1["symbol"], leg1["side"], leg1["qty"], leg1.get("price")
+            )
+            latency1 = (time.perf_counter() - start) * 1000
+            details["latency_ms"]["leg1"] = latency1
+            details["responses"]["leg1"] = resp1
+            if latency1 > self.max_latency_ms:
+                logger.warning(f"Leg1 latency {latency1:.2f}ms exceeds {self.max_latency_ms}ms")
+        except Exception as e:
+            logger.exception("First leg failed")
+            details["error"] = str(e)
+            return ExecResult(False, "first_leg_failed", details)
+
+        # Second leg
+        try:
+            start = time.perf_counter()
+            resp2 = self.exchange.place_order_ioc(
+                leg2["symbol"], leg2["side"], leg2["qty"], leg2.get("price")
+            )
+            latency2 = (time.perf_counter() - start) * 1000
+            details["latency_ms"]["leg2"] = latency2
+            details["responses"]["leg2"] = resp2
+            if latency2 > self.max_latency_ms:
+                logger.warning(f"Leg2 latency {latency2:.2f}ms exceeds {self.max_latency_ms}ms")
+        except Exception as e:
+            logger.exception("Second leg failed")
+            details["error"] = str(e)
+            # Attempt rollback
+            rollback_side = "SELL" if leg1["side"].upper() == "BUY" else "BUY"
+            try:
+                self.exchange.place_order_ioc(
+                    leg1["symbol"], rollback_side, leg1["qty"], leg1.get("price")
+                )
+            except Exception as re:
+                logger.exception("Rollback failed")
+                details["rollback_error"] = str(re)
+            return ExecResult(False, "second_leg_failed", details)
+
+        return ExecResult(True, details=details)

--- a/core/execution/types.py
+++ b/core/execution/types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+@dataclass
+class ExecResult:
+    """Result of an execution attempt."""
+    ok: bool
+    reason: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)

--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -2,5 +2,7 @@ class RiskManager:
     """Very small placeholder risk manager."""
 
     def check(self, opportunity: dict) -> bool:
-        """Approve trade if quantity is positive."""
+        """Approve trade if all quantities are positive."""
+        if "legs" in opportunity:
+            return all(leg.get("qty", 0) > 0 for leg in opportunity["legs"])
         return opportunity.get("qty", 0) > 0

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,17 +1,17 @@
 from core.risk.manager import RiskManager
 from core.execution.executor import Executor
+from core.execution.types import ExecResult
 from core.exchange.base import Exchange
 
 class Pipeline:
     """End-to-end trading pipeline."""
 
-    def __init__(self, exchange: Exchange):
+    def __init__(self, exchange: Exchange, max_latency_ms: int = 1000):
         self.risk = RiskManager()
-        self.executor = Executor(exchange)
+        self.executor = Executor(exchange, max_latency_ms)
 
-    def run(self, opportunity: dict):
+    def run(self, opportunity: dict) -> ExecResult:
         if not self.risk.check(opportunity):
-            return {"status": "rejected"}
-        return self.executor.execute(
-            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
-        )
+            return ExecResult(False, "risk_rejected")
+        leg1, leg2 = opportunity["legs"]
+        return self.executor.execute_pair(leg1, leg2)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,11 @@ class DummyExchange(Exchange):
         self.orders = []
 
     def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        raise NotImplementedError
+
+    def place_order_ioc(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
         self.orders.append((symbol, side, quantity, price))
         return {"status": "filled"}
 
@@ -14,6 +19,13 @@ class DummyExchange(Exchange):
 def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
-    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
-    assert result["status"] == "filled"
+    opportunity = {
+        "legs": [
+            {"symbol": "BTCUSDT", "side": "BUY", "qty": 1},
+            {"symbol": "ETHUSDT", "side": "SELL", "qty": 1},
+        ]
+    }
+    result = pipe.run(opportunity)
+    assert result.ok
     assert exchange.orders[0][0] == "BTCUSDT"
+    assert exchange.orders[1][0] == "ETHUSDT"


### PR DESCRIPTION
## Summary
- add `ExecResult` dataclass for standard execution responses
- implement latency-tracked IOC order execution with rollback on failure
- update pipeline, risk checks, and tests for new execution flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dbd79d128832ca1b64c1fd0c44bcc