### PR TITLE
feat: add configurable risk guard manager

### DIFF
--- a/core/risk/guards.py
+++ b/core/risk/guards.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from core.data.logger import logger
+
+
+@dataclass
+class RiskCfg:
+    """Risk thresholds in USD."""
+    max_notional_usd: float = float("inf")
+    max_sym_exposure_usd: float = float("inf")
+    max_exposure_usd: float = float("inf")
+
+    @classmethod
+    def from_dict(cls, cfg: dict) -> "RiskCfg":
+        """Create config from dictionary values."""
+        return cls(
+            max_notional_usd=cfg.get("max_notional_usd", float("inf")),
+            max_sym_exposure_usd=cfg.get("max_sym_exposure_usd", float("inf")),
+            max_exposure_usd=cfg.get("max_exposure_usd", float("inf")),
+        )
+
+
+class RiskManager:
+    """Evaluate trades against configured thresholds."""
+
+    def __init__(self, cfg: dict | RiskCfg):
+        self.cfg = cfg if isinstance(cfg, RiskCfg) else RiskCfg.from_dict(cfg or {})
+
+    def check(
+        self,
+        symbol: str,
+        notional_usd: float,
+        sym_exposure_usd: float,
+        ex_exposure_usd: float,
+    ) -> tuple[bool, str]:
+        """Return (allowed, reason) for a proposed trade."""
+        if notional_usd > self.cfg.max_notional_usd:
+            reason = (
+                f"notional {notional_usd} exceeds limit {self.cfg.max_notional_usd}"
+            )
+            logger.warning(f"risk_reject symbol={symbol} reason={reason}")
+            return False, reason
+        if sym_exposure_usd > self.cfg.max_sym_exposure_usd:
+            reason = (
+                f"symbol exposure {sym_exposure_usd} exceeds limit {self.cfg.max_sym_exposure_usd}"
+            )
+            logger.warning(f"risk_reject symbol={symbol} reason={reason}")
+            return False, reason
+        if ex_exposure_usd > self.cfg.max_exposure_usd:
+            reason = (
+                f"exchange exposure {ex_exposure_usd} exceeds limit {self.cfg.max_exposure_usd}"
+            )
+            logger.warning(f"risk_reject symbol={symbol} reason={reason}")
+            return False, reason
+        return True, "ok"

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,17 +1,22 @@
-from core.risk.manager import RiskManager
+from core.risk.guards import RiskManager
 from core.execution.executor import Executor
 from core.exchange.base import Exchange
+
 
 class Pipeline:
     """End-to-end trading pipeline."""
 
-    def __init__(self, exchange: Exchange):
-        self.risk = RiskManager()
+    def __init__(self, exchange: Exchange, risk_cfg: dict | None = None):
+        self.risk = RiskManager(risk_cfg or {})
         self.executor = Executor(exchange)
 
     def run(self, opportunity: dict):
-        if not self.risk.check(opportunity):
-            return {"status": "rejected"}
+        notional = opportunity.get("notional_usd", opportunity.get("qty", 0) * opportunity.get("price", 0))
+        sym_exp = opportunity.get("sym_exposure_usd", 0)
+        ex_exp = opportunity.get("ex_exposure_usd", 0)
+        ok, reason = self.risk.check(opportunity["symbol"], notional, sym_exp, ex_exp)
+        if not ok:
+            return {"status": "rejected", "reason": reason}
         return self.executor.execute(
             opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,3 +17,20 @@ def test_pipeline_executes_order():
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
     assert result["status"] == "filled"
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_rejects_when_risk_limit_hit():
+    exchange = DummyExchange()
+    cfg = {"max_notional_usd": 10, "max_sym_exposure_usd": 100, "max_exposure_usd": 100}
+    pipe = Pipeline(exchange, risk_cfg=cfg)
+    result = pipe.run({
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "qty": 1,
+        "price": 20,
+        "notional_usd": 20,
+        "sym_exposure_usd": 0,
+        "ex_exposure_usd": 0,
+    })
+    assert result["status"] == "rejected"
+    assert "notional" in result["reason"]


### PR DESCRIPTION
## Summary
- add RiskCfg dataclass and RiskManager that enforce notional and exposure thresholds with logging
- wire pipeline to use new risk guards and return rejection reason
- cover risk rejection behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dbd872b48832c8f7063d5111fa518