### PR TITLE
Introduce typed PipelineResult and failure logging

### DIFF
--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,6 +1,20 @@
+from dataclasses import dataclass
+from typing import Optional
+
 from core.risk.manager import RiskManager
 from core.execution.executor import Executor
 from core.exchange.base import Exchange
+from core.data.logger import logger
+
+
+@dataclass
+class PipelineResult:
+    """Typed result of a pipeline run."""
+
+    accepted: bool
+    reason: str
+    execution: Optional[dict] = None
+
 
 class Pipeline:
     """End-to-end trading pipeline."""
@@ -9,9 +23,19 @@ class Pipeline:
         self.risk = RiskManager()
         self.executor = Executor(exchange)
 
-    def run(self, opportunity: dict):
+    def run(self, opportunity: dict) -> PipelineResult:
         if not self.risk.check(opportunity):
-            return {"status": "rejected"}
-        return self.executor.execute(
-            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
-        )
+            logger.info("rejected")
+            return PipelineResult(False, "rejected")
+
+        try:
+            execution = self.executor.execute(
+                opportunity["symbol"],
+                opportunity["side"],
+                opportunity["qty"],
+                opportunity.get("price"),
+            )
+            return PipelineResult(True, "accepted", execution)
+        except Exception:
+            logger.exception("exec_fail")
+            return PipelineResult(False, "exec_fail")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from orchestrator.pipeline import Pipeline
+from orchestrator.pipeline import Pipeline, PipelineResult
 from core.exchange.base import Exchange
 
 
@@ -15,5 +15,32 @@ def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
-    assert result["status"] == "filled"
+    assert isinstance(result, PipelineResult)
+    assert result.accepted is True
+    assert result.execution == {"status": "filled"}
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_rejects_order():
+    exchange = DummyExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 0})
+    assert result.accepted is False
+    assert result.reason == "rejected"
+    assert result.execution is None
+
+
+class FailingExchange(Exchange):
+    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        raise RuntimeError("boom")
+
+
+def test_pipeline_exec_fail_logs_and_returns(caplog):
+    exchange = FailingExchange()
+    pipe = Pipeline(exchange)
+    with caplog.at_level("ERROR", logger="omni"):
+        result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    assert result.accepted is False
+    assert result.reason == "exec_fail"
+    assert result.execution is None
+    assert any("exec_fail" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- add `PipelineResult` dataclass capturing acceptance, reason, and execution details
- log `rejected` and `exec_fail` cases in the pipeline
- update tests for the typed pipeline interface, including rejection and execution failure scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbd92b264832caa1dc006677223b8