### PR TITLE
Add basis trading backtest utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,35 @@ curl -s http://localhost:3000/login
 ```bash
 make test
 ```
+
+## Basis Backtest
+
+`research.simulate_basis` runs a simple basis-trading backtest.
+
+### Input Data
+
+Provide spot and futures prices as CSV or Parquet with columns:
+
+```csv
+timestamp,spot,future
+2024-01-01T00:00:00Z,100,105
+2024-01-01T00:01:00Z,101,104
+```
+
+### Usage
+
+```python
+import pandas as pd
+from research import BTConfig, simulate_basis
+
+df = pd.read_csv("prices.csv")
+cfg = BTConfig(fee=0.001, slippage=0.0005, latency=1, long_entry=0.02, short_entry=0.02)
+result = simulate_basis(df, cfg)
+print(result)
+```
+
+Assumptions:
+
+- One unit notional per leg.
+- Fees and slippage applied to each open/close leg.
+- Trades enter when the basis exceeds thresholds and exit when it crosses zero.

--- a/research/__init__.py
+++ b/research/__init__.py
@@ -1,1 +1,6 @@
 """Research and backtesting utilities."""
+
+from .basis import BTConfig, simulate_basis
+
+__all__ = ["BTConfig", "simulate_basis"]
+

--- a/research/basis.py
+++ b/research/basis.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class BTConfig:
+    """Backtest configuration.
+
+    Attributes
+    ----------
+    fee: float
+        Fractional fee applied to each leg of the trade.
+    slippage: float
+        Fractional slippage per leg.
+    latency: int
+        Number of rows to delay execution after a signal.
+    long_entry: float
+        Basis threshold for entering a long basis trade
+        (long future / short spot).
+    short_entry: float
+        Basis threshold for entering a short basis trade
+        (short future / long spot).
+    """
+
+    fee: float = 0.0
+    slippage: float = 0.0
+    latency: int = 0
+    long_entry: float = 0.0
+    short_entry: float = 0.0
+
+
+def simulate_basis(df: pd.DataFrame, cfg: BTConfig) -> Dict[str, float]:
+    """Simulate a simple basis-trading strategy.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``spot`` and ``future`` price columns sorted by
+        time. Example CSV/Parquet structure::
+
+            timestamp,spot,future
+            2024-01-01T00:00:00Z,100,105
+            2024-01-01T00:01:00Z,101,104
+
+    cfg:
+        Backtest configuration.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``pnl``, ``trades``, ``sharpe`` and ``max_drawdown``.
+
+    Notes
+    -----
+    - Uses one unit of notional per leg.
+    - Fees and slippage apply to each of the four legs (open/close spot & future).
+    - ``latency`` delays execution by N rows after a signal is generated.
+    - Entries occur when basis ``> cfg.short_entry`` (short basis) or
+      ``< -cfg.long_entry`` (long basis) and exit when basis crosses zero.
+    """
+
+    if not {"spot", "future"}.issubset(df.columns):
+        raise ValueError("df must contain 'spot' and 'future' columns")
+
+    data = df.reset_index(drop=True).copy()
+    data["basis"] = (data["future"] - data["spot"]) / data["spot"]
+
+    trades = []
+    position = 0  # 1 = long basis, -1 = short basis
+    entry_spot = entry_future = 0.0
+
+    for i in range(len(data) - cfg.latency):
+        spot_price = data.at[i + cfg.latency, "spot"]
+        future_price = data.at[i + cfg.latency, "future"]
+        basis = data.at[i, "basis"]
+
+        if position == 0:
+            if basis > cfg.short_entry:
+                position = -1
+                entry_spot = spot_price
+                entry_future = future_price
+            elif basis < -cfg.long_entry:
+                position = 1
+                entry_spot = spot_price
+                entry_future = future_price
+        elif position == -1 and basis <= 0:
+            exit_spot = spot_price
+            exit_future = future_price
+            pnl = (entry_future - exit_future) + (exit_spot - entry_spot)
+            cost = (cfg.fee + cfg.slippage) * (
+                entry_future + entry_spot + exit_future + exit_spot
+            )
+            trades.append(pnl - cost)
+            position = 0
+        elif position == 1 and basis >= 0:
+            exit_spot = spot_price
+            exit_future = future_price
+            pnl = (exit_future - entry_future) - (exit_spot - entry_spot)
+            cost = (cfg.fee + cfg.slippage) * (
+                entry_future + entry_spot + exit_future + exit_spot
+            )
+            trades.append(pnl - cost)
+            position = 0
+
+    pnl = float(np.sum(trades))
+    n_trades = len(trades)
+    if n_trades > 1 and np.std(trades) != 0:
+        sharpe = float(np.mean(trades) / np.std(trades) * np.sqrt(n_trades))
+    else:
+        sharpe = 0.0
+
+    if n_trades:
+        equity = np.cumsum(trades)
+        running_max = np.maximum.accumulate(equity)
+        max_drawdown = float(np.max(running_max - equity))
+    else:
+        max_drawdown = 0.0
+
+    return {
+        "pnl": pnl,
+        "trades": n_trades,
+        "sharpe": sharpe,
+        "max_drawdown": max_drawdown,
+    }

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from research import BTConfig, simulate_basis
+
+
+def test_simulate_basis_single_trade():
+    df = pd.DataFrame(
+        {
+            "spot": [100, 101, 102, 103, 102, 101],
+            "future": [105, 104, 103, 102, 103, 105],
+        }
+    )
+    cfg = BTConfig(long_entry=0.02, short_entry=0.02)
+    result = simulate_basis(df, cfg)
+    assert result["trades"] == 1
+    assert abs(result["pnl"] - 6) < 1e-9
+    assert result["max_drawdown"] == 0.0


### PR DESCRIPTION
## Summary
- add `BTConfig` dataclass capturing fee, slippage, latency and entry thresholds
- implement `simulate_basis` backtest computing PnL, Sharpe and drawdown
- document basis backtest usage and expected CSV/Parquet schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbd9c1e54832cbb550b0a487f141f