### PR TITLE
Add logger singleton and risk manager tests

### DIFF
--- a/core/data/logger.py
+++ b/core/data/logger.py
@@ -1,12 +1,29 @@
 import logging
 import json
 
+
 class JSONFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         return json.dumps({"level": record.levelname, "msg": record.getMessage()})
 
-handler = logging.StreamHandler()
-handler.setFormatter(JSONFormatter())
-logger = logging.getLogger("omni")
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+
+_LOGGER: logging.Logger | None = None
+
+
+def get_logger() -> logging.Logger:
+    """Return module-level logger configured once."""
+
+    global _LOGGER
+    if _LOGGER is None:
+        logger = logging.getLogger("omni")
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(JSONFormatter())
+            logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        _LOGGER = logger
+    return _LOGGER
+
+
+# Backwards-compatible logger object
+logger = get_logger()

--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -1,6 +1,9 @@
 class RiskManager:
     """Very small placeholder risk manager."""
 
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+
     def check(self, opportunity: dict) -> bool:
         """Approve trade if quantity is positive."""
         return opportunity.get("qty", 0) > 0

--- a/tests/test_logger_singleton.py
+++ b/tests/test_logger_singleton.py
@@ -1,0 +1,9 @@
+from core.data.logger import get_logger
+from core.data.logger import get_logger as get_logger_again
+
+
+def test_get_logger_singleton():
+    logger1 = get_logger()
+    logger2 = get_logger_again()
+    assert logger1 is logger2
+    assert len(logger1.handlers) == 1

--- a/tests/test_risk_limits.py
+++ b/tests/test_risk_limits.py
@@ -1,0 +1,9 @@
+from core.risk.manager import RiskManager
+
+
+def test_risk_manager_accepts_positive_qty_and_rejects_non_positive():
+    config = {"max_position": 10}
+    rm = RiskManager(config)
+    assert rm.check({"qty": 1})
+    assert not rm.check({"qty": 0})
+    assert not rm.check({"qty": -1})


### PR DESCRIPTION
## Summary
- add `get_logger` singleton factory ensuring only one handler
- allow `RiskManager` initialization with config
- test logger singleton behavior and risk manager accept/reject paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbdaea488832c974b9bc9d937b2b3