### PR TITLE
Add metrics smoke script and testing targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ PY := python3
 PIP := pip
 DC := docker compose
 APP := omni-arb
+PORT ?= 8000
 
 # ===== Default =====
 .PHONY: help
 help:
-	@echo "Targets: setup | up | down | logs | logger | orchestrator | backtest | train-ppo | test"
+        @echo "Targets: setup | up | down | logs | logger | orchestrator | backtest | train-ppo | metrics-smoke | test"
 
 # ===== Setup (py + docker) =====
 .PHONY: setup
@@ -53,7 +54,11 @@ backtest:
 
 .PHONY: train-ppo
 train-ppo:
-	. .venv/bin/activate && $(PY) apps/research/train_ppo.py --symbol BTCUSDT --epochs 10
+        . .venv/bin/activate && $(PY) apps/research/train_ppo.py --symbol BTCUSDT --epochs 10
+
+.PHONY: metrics-smoke
+metrics-smoke:
+        . .venv/bin/activate && $(PY) scripts/metrics_smoke.py --port $(PORT)
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ curl -s http://localhost:3000/login
 ```bash
 make test
 ```
+
+## Metrics Smoke Test
+
+Run a tiny exporter that emits dummy Prometheus metrics:
+
+```bash
+make metrics-smoke PORT=8000
+curl -s http://localhost:8000/metrics
+```
+
+The `PORT` variable is optional and defaults to `8000`.

--- a/scripts/metrics_smoke.py
+++ b/scripts/metrics_smoke.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Minimal Prometheus metrics exporter for smoke testing.
+
+Usage:
+    python scripts/metrics_smoke.py --port 8000
+
+This script starts a Prometheus exporter on the given port and updates a
+single gauge with random values a few times before exiting.
+"""
+
+import argparse
+import random
+import time
+
+from prometheus_client import Gauge, start_http_server
+
+
+def main(port: int) -> None:
+    gauge = Gauge("godx_smoke_metric", "Random value for smoke testing")
+    start_http_server(port)
+    for _ in range(5):
+        gauge.set(random.random())
+        time.sleep(0.5)
+    print(f"Exported dummy metrics on http://localhost:{port}/metrics")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run a tiny metrics exporter")
+    parser.add_argument("--port", type=int, default=8000, help="Port to export metrics on")
+    args = parser.parse_args()
+    main(args.port)


### PR DESCRIPTION
## Summary
- add Makefile variable and `metrics-smoke` target to run a dummy Prometheus exporter
- document metrics smoke usage and `make test` in README
- include standalone `metrics_smoke.py` script for quick metrics emission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbdbf84f8832c95369869289c7e45