### PR TITLE
Add retry logic and error handling to executor

### DIFF
--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,12 +1,29 @@
 from core.exchange.base import Exchange
 from core.data.logger import logger
+import time
+
 
 class Executor:
-    """Simple trade executor."""
+    """Simple trade executor with basic retry handling."""
 
-    def __init__(self, exchange: Exchange):
+    def __init__(self, exchange: Exchange, retries: int = 0, retry_delay: float = 0.0):
         self.exchange = exchange
+        self.retries = retries
+        self.retry_delay = retry_delay
 
     def execute(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
-        logger.info(f"execute_order symbol={symbol} side={side} qty={quantity} price={price}")
-        return self.exchange.place_order(symbol, side, quantity, price)
+        logger.info(
+            f"execute_order symbol={symbol} side={side} qty={quantity} price={price}"
+        )
+        attempt = 0
+        while True:
+            try:
+                return self.exchange.place_order(symbol, side, quantity, price)
+            except Exception as e:  # broad catch to surface any order issues
+                logger.error(f"place_order failed: {e}")
+                if attempt >= self.retries:
+                    return {"status": "error", "detail": str(e)}
+                attempt += 1
+                if self.retry_delay:
+                    time.sleep(self.retry_delay)
+                logger.info(f"retrying order, attempt {attempt}")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,8 +6,30 @@ class DummyExchange(Exchange):
     def __init__(self):
         self.orders = []
 
-    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+    def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
         self.orders.append((symbol, side, quantity, price))
+        return {"status": "filled"}
+
+
+class FailingExchange(Exchange):
+    def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        raise RuntimeError("boom")
+
+
+class FlakyExchange(Exchange):
+    def __init__(self):
+        self.calls = 0
+
+    def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("temporary")
         return {"status": "filled"}
 
 
@@ -17,3 +39,20 @@ def test_pipeline_executes_order():
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
     assert result["status"] == "filled"
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_handles_exchange_error():
+    exchange = FailingExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    assert result["status"] == "error"
+    assert "boom" in result["detail"]
+
+
+def test_pipeline_retries_transient_failure():
+    exchange = FlakyExchange()
+    pipe = Pipeline(exchange)
+    pipe.executor.retries = 1
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    assert result["status"] == "filled"
+    assert exchange.calls == 2


### PR DESCRIPTION
## Summary
- wrap order execution in try/except and return error details
- add optional retry logic for transient failures
- expand pipeline tests to cover error and retry scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbddb60b8832ca6465421ab166f65