### PR TITLE
Add risk thresholds and validation

### DIFF
--- a/config/risk.yml
+++ b/config/risk.yml
@@ -1,2 +1,2 @@
-max_position: 10
-max_notional: 100000
+max_pos_usd: 100000
+max_leverage: 5

--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -1,6 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import yaml
+
+
 class RiskManager:
     """Very small placeholder risk manager."""
 
-    def check(self, opportunity: dict) -> bool:
-        """Approve trade if quantity is positive."""
-        return opportunity.get("qty", 0) > 0
+    def __init__(self) -> None:
+        cfg_path = Path(__file__).resolve().parents[2] / "config" / "risk.yml"
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+        self.max_pos_usd = cfg.get("max_pos_usd", float("inf"))
+        self.max_leverage = cfg.get("max_leverage", float("inf"))
+
+    def check(self, opportunity: dict) -> Tuple[bool, str]:
+        """Validate opportunity against basic risk checks."""
+        qty = opportunity.get("qty", 0)
+        if qty <= 0:
+            return False, "non-positive quantity"
+
+        pos_usd = opportunity.get("pos_usd", 0)
+        if pos_usd > self.max_pos_usd:
+            return False, f"pos_usd {pos_usd} exceeds max {self.max_pos_usd}"
+
+        leverage = opportunity.get("leverage", 0)
+        if leverage > self.max_leverage:
+            return False, f"leverage {leverage} exceeds max {self.max_leverage}"
+
+        return True, "approved"

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -10,8 +10,9 @@ class Pipeline:
         self.executor = Executor(exchange)
 
     def run(self, opportunity: dict):
-        if not self.risk.check(opportunity):
-            return {"status": "rejected"}
+        approved, reason = self.risk.check(opportunity)
+        if not approved:
+            return {"status": "rejected", "reason": reason}
         return self.executor.execute(
             opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
         )

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,23 @@
+from core.risk.manager import RiskManager
+
+
+def test_pos_usd_boundary():
+    rm = RiskManager()
+    ok, _ = rm.check({"qty": 1, "pos_usd": rm.max_pos_usd, "leverage": 1})
+    assert ok
+    ok, reason = rm.check({"qty": 1, "pos_usd": rm.max_pos_usd + 1, "leverage": 1})
+    assert not ok and "pos_usd" in reason
+
+
+def test_leverage_boundary():
+    rm = RiskManager()
+    ok, _ = rm.check({"qty": 1, "leverage": rm.max_leverage})
+    assert ok
+    ok, reason = rm.check({"qty": 1, "leverage": rm.max_leverage + 0.1})
+    assert not ok and "leverage" in reason
+
+
+def test_rejects_non_positive_qty():
+    rm = RiskManager()
+    ok, reason = rm.check({"qty": 0})
+    assert not ok and "quantity" in reason


### PR DESCRIPTION
## Summary
- load risk thresholds from `config/risk.yml`
- validate `pos_usd` and `leverage` with descriptive rejections
- return approval status and reason throughout pipeline
- add boundary tests for risk manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dbde61420832ca3e63de6a0aa7661