### PR TITLE
Add structured execution result with logging

### DIFF
--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,6 +1,18 @@
+from dataclasses import dataclass
+
 from core.risk.manager import RiskManager
 from core.execution.executor import Executor
 from core.exchange.base import Exchange
+from core.data.logger import logger
+
+
+@dataclass
+class ExecutionResult:
+    """Structured result of pipeline execution."""
+
+    status: str
+    details: dict
+    opportunity: dict
 
 class Pipeline:
     """End-to-end trading pipeline."""
@@ -9,9 +21,24 @@ class Pipeline:
         self.risk = RiskManager()
         self.executor = Executor(exchange)
 
-    def run(self, opportunity: dict):
+    def run(self, opportunity: dict) -> ExecutionResult:
         if not self.risk.check(opportunity):
-            return {"status": "rejected"}
-        return self.executor.execute(
-            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
+            logger.info(f"rejected_opportunity {opportunity}")
+            return ExecutionResult(
+                status="rejected",
+                details={"reason": "risk_check_failed"},
+                opportunity=opportunity,
+            )
+
+        logger.info(f"accepted_opportunity {opportunity}")
+        details = self.executor.execute(
+            opportunity["symbol"],
+            opportunity["side"],
+            opportunity["qty"],
+            opportunity.get("price"),
+        )
+        return ExecutionResult(
+            status=details.get("status", "unknown"),
+            details=details,
+            opportunity=opportunity,
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from orchestrator.pipeline import Pipeline
+from orchestrator.pipeline import ExecutionResult, Pipeline
 from core.exchange.base import Exchange
 
 
@@ -15,5 +15,19 @@ def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
-    assert result["status"] == "filled"
+    assert isinstance(result, ExecutionResult)
+    assert result.status == "filled"
+    assert result.details["status"] == "filled"
+    assert result.opportunity["symbol"] == "BTCUSDT"
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_rejects_order():
+    exchange = DummyExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 0})
+    assert isinstance(result, ExecutionResult)
+    assert result.status == "rejected"
+    assert result.details["reason"] == "risk_check_failed"
+    assert result.opportunity["qty"] == 0
+    assert exchange.orders == []


### PR DESCRIPTION
## Summary
- define `ExecutionResult` dataclass carrying status, details, and original opportunity
- log accepted and rejected opportunities and return structured results
- update pipeline tests to consume `ExecutionResult` and cover rejection case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbdecf400832ca848ba47ece2e9b7