### PR TITLE
Implement backtest metrics and CLI

### DIFF
--- a/research/backtest.py
+++ b/research/backtest.py
@@ -1,4 +1,101 @@
-"""Simple backtest placeholder."""
+"""Backtesting utilities.
 
-def run():
-    return {"pnl": 0}
+This module provides a simple backtesting engine that operates on a
+price series and a user supplied strategy.  It exposes both a Python
+API via :func:`run` and a CLI that can be invoked with ``python -m
+research.backtest`` to run the backtest against data stored in CSV or
+Parquet files.
+"""
+
+from __future__ import annotations
+
+import argparse
+from math import sqrt
+from pathlib import Path
+from typing import Callable, Dict
+
+import pandas as pd
+
+
+def run(price_series: pd.Series, strategy: Callable[[pd.Series], pd.Series]) -> Dict[str, float]:
+    """Execute a simple backtest.
+
+    Parameters
+    ----------
+    price_series:
+        Series of asset prices ordered by time.
+    strategy:
+        Callable that accepts the ``price_series`` and returns a series of
+        positions (e.g. ``1`` for long, ``-1`` for short) indexed the same
+        way as ``price_series``.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``cumulative_pnl``, ``sharpe_ratio`` and
+        ``max_drawdown``.
+    """
+
+    prices = price_series.astype(float)
+    positions = strategy(prices).reindex(prices.index).astype(float)
+
+    returns = prices.pct_change().fillna(0.0)
+    pnl = positions.shift(1).fillna(0.0) * returns
+    cumulative = pnl.cumsum()
+
+    mean = pnl.mean()
+    std = pnl.std(ddof=0)
+    sharpe = (mean / std * sqrt(len(pnl))) if std != 0 else 0.0
+
+    drawdown = cumulative - cumulative.cummax()
+    max_drawdown = drawdown.min() if not drawdown.empty else 0.0
+
+    return {
+        "cumulative_pnl": float(cumulative.iloc[-1]) if not cumulative.empty else 0.0,
+        "sharpe_ratio": float(sharpe),
+        "max_drawdown": float(max_drawdown),
+    }
+
+
+def _load_prices(path: Path, column: str) -> pd.Series:
+    """Load a price series from a CSV or Parquet file."""
+
+    if path.suffix.lower() == ".csv":
+        df = pd.read_csv(path)
+    elif path.suffix.lower() in {".parquet", ".pq"}:
+        df = pd.read_parquet(path)
+    else:
+        raise ValueError(f"Unsupported file format: {path.suffix}")
+    if column not in df.columns:
+        raise ValueError(f"Column '{column}' not found in data file")
+    return df[column]
+
+
+def _buy_and_hold(prices: pd.Series) -> pd.Series:
+    """Trivial strategy that is always long one unit."""
+
+    return pd.Series(1.0, index=prices.index)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a simple backtest over price data")
+    parser.add_argument("data", type=str, help="Path to CSV or Parquet file containing prices")
+    parser.add_argument("--column", default="close", help="Column name containing prices")
+    parser.add_argument(
+        "--strategy",
+        default="buy_and_hold",
+        choices=["buy_and_hold"],
+        help="Strategy to execute",
+    )
+    args = parser.parse_args()
+
+    prices = _load_prices(Path(args.data), args.column)
+    strategies = {"buy_and_hold": _buy_and_hold}
+    metrics = run(prices, strategies[args.strategy])
+    for k, v in metrics.items():
+        print(f"{k}: {v}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+
+from research.backtest import run
+
+
+def always_long(prices: pd.Series) -> pd.Series:
+    """Return a constant long position."""
+
+    return pd.Series(1.0, index=prices.index)
+
+
+def test_backtest_metrics():
+    prices = pd.Series([1, 2, 1, 2])
+    metrics = run(prices, always_long)
+
+    assert metrics["cumulative_pnl"] == pytest.approx(1.5)
+    assert metrics["sharpe_ratio"] == pytest.approx(1.1547, rel=1e-3)
+    assert metrics["max_drawdown"] == pytest.approx(-0.5)
+


### PR DESCRIPTION
## Summary
- Replace placeholder backtest with parameterized function computing cumulative PnL, Sharpe ratio and max drawdown
- Add CLI to run backtests on CSV/Parquet data with a basic buy-and-hold strategy
- Introduce tests verifying backtest metric calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbdf48b74832c94c12caebc3e9a9e