### PR TITLE
feat: add metrics library and instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,22 @@ curl -s http://localhost:3000/login
 ```bash
 make test
 ```
+
+## Metrics
+
+Prometheus-style metrics are available via helpers in `libs/metrics.py`. Metrics
+can be exported over HTTP or pushed to a Pushgateway.
+
+```python
+from libs.metrics import init_metrics, push_metrics
+
+# Start an HTTP server on port 8000
+init_metrics(port=8000)
+
+# Push collected metrics to a gateway
+push_metrics(job="godx", gateway="localhost:9091")
+```
+
+The executor and risk manager automatically publish latency and error counters
+(`executor_execute_latency_seconds`, `executor_execute_errors_total`,
+`risk_manager_check_latency_seconds`, `risk_manager_check_errors_total`).

--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,5 +1,7 @@
 from core.exchange.base import Exchange
 from core.data.logger import logger
+from libs.metrics import counter, gauge
+import time
 
 class Executor:
     """Simple trade executor."""
@@ -7,6 +9,22 @@ class Executor:
     def __init__(self, exchange: Exchange):
         self.exchange = exchange
 
+    execute_latency = gauge(
+        "executor_execute_latency_seconds", "Latency of execute() calls"
+    )
+    execute_errors = counter(
+        "executor_execute_errors_total", "Total errors during execute()"
+    )
+
     def execute(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
-        logger.info(f"execute_order symbol={symbol} side={side} qty={quantity} price={price}")
-        return self.exchange.place_order(symbol, side, quantity, price)
+        start = time.perf_counter()
+        try:
+            logger.info(
+                f"execute_order symbol={symbol} side={side} qty={quantity} price={price}"
+            )
+            return self.exchange.place_order(symbol, side, quantity, price)
+        except Exception:
+            self.execute_errors.inc()
+            raise
+        finally:
+            self.execute_latency.set(time.perf_counter() - start)

--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -1,6 +1,24 @@
+import time
+from libs.metrics import counter, gauge
+
+
 class RiskManager:
     """Very small placeholder risk manager."""
 
+    check_latency = gauge(
+        "risk_manager_check_latency_seconds", "Latency of risk checks"
+    )
+    check_errors = counter(
+        "risk_manager_check_errors_total", "Total errors during risk checks"
+    )
+
     def check(self, opportunity: dict) -> bool:
         """Approve trade if quantity is positive."""
-        return opportunity.get("qty", 0) > 0
+        start = time.perf_counter()
+        try:
+            return opportunity.get("qty", 0) > 0
+        except Exception:
+            self.check_errors.inc()
+            raise
+        finally:
+            self.check_latency.set(time.perf_counter() - start)

--- a/libs/metrics.py
+++ b/libs/metrics.py
@@ -1,0 +1,49 @@
+"""Simple Prometheus metrics helpers.
+
+Provides Counter and Gauge factories backed by a shared registry. Metrics can be
+exposed via an HTTP server or pushed to a Prometheus Pushgateway.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, push_to_gateway, start_http_server
+
+_registry = CollectorRegistry()
+
+
+def init_metrics(port: Optional[int] = None, registry: CollectorRegistry | None = None) -> CollectorRegistry:
+    """Initialise the metrics subsystem.
+
+    Args:
+        port: If provided, start an HTTP metrics exporter on this port.
+        registry: Optional external registry to use instead of the default.
+
+    Returns:
+        The CollectorRegistry in use.
+    """
+    global _registry
+    if registry is not None:
+        _registry = registry
+    if port is not None:
+        start_http_server(port, registry=_registry)
+    return _registry
+
+
+def counter(name: str, documentation: str, labels: Optional[Iterable[str]] = None) -> Counter:
+    """Create or return a Counter metric."""
+    if labels:
+        return Counter(name, documentation, labelnames=list(labels), registry=_registry)
+    return Counter(name, documentation, registry=_registry)
+
+
+def gauge(name: str, documentation: str, labels: Optional[Iterable[str]] = None) -> Gauge:
+    """Create or return a Gauge metric."""
+    if labels:
+        return Gauge(name, documentation, labelnames=list(labels), registry=_registry)
+    return Gauge(name, documentation, registry=_registry)
+
+
+def push_metrics(job: str, gateway: str = "localhost:9091") -> None:
+    """Push all metrics to a Prometheus Pushgateway."""
+    push_to_gateway(gateway, job=job, registry=_registry)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+prometheus_client>=0.16.0


### PR DESCRIPTION
## Summary
- add reusable Prometheus metrics helpers
- instrument executor and risk manager with latency/error metrics
- document metrics usage and add dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbdfb52f0832c970d7bd281766509