### PR TITLE
feat: centralize logging utilities

### DIFF
--- a/core/data/logger.py
+++ b/core/data/logger.py
@@ -1,12 +1,8 @@
-import logging
-import json
+from libs.logging_utils import get_logger
 
-class JSONFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        return json.dumps({"level": record.levelname, "msg": record.getMessage()})
+logger = get_logger("omni")
 
-handler = logging.StreamHandler()
-handler.setFormatter(JSONFormatter())
-logger = logging.getLogger("omni")
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+
+def write_event(event: str) -> None:
+    """Write a structured event using the shared logger."""
+    logger.info(event)

--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,5 +1,8 @@
 from core.exchange.base import Exchange
-from core.data.logger import logger
+from libs.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
 
 class Executor:
     """Simple trade executor."""

--- a/libs/logging_utils.py
+++ b/libs/logging_utils.py
@@ -1,0 +1,40 @@
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Dict
+
+
+class JsonFormatter(logging.Formatter):
+    """Format logs as JSON with ISO-8601 timestamps."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "name": record.name,
+            "msg": record.getMessage(),
+        }
+        return json.dumps(payload)
+
+
+_loggers: Dict[str, logging.Logger] = {}
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger.
+
+    Removes any existing handlers, attaches a single ``StreamHandler`` with
+    ``JsonFormatter``, disables propagation and caches the logger instance.
+    """
+    if name in _loggers:
+        return _loggers[name]
+
+    logger = logging.getLogger(name)
+    logger.handlers = []
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    _loggers[name] = logger
+    return logger


### PR DESCRIPTION
## Summary
- add reusable `JsonFormatter` and `get_logger` helper with ISO-8601 timestamps
- expose `write_event` from a lean core logger wrapper
- update executor to build its own logger via the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dc414e8c8832c93fcb451c5d7da8d