### PR TITLE
refactor: typed exec results with rollback

### DIFF
--- a/core/execution/__init__.py
+++ b/core/execution/__init__.py
@@ -1,1 +1,6 @@
 """Order execution components."""
+
+from .executor import Executor  # noqa: F401
+from .result import ExecResult  # noqa: F401
+
+__all__ = ["Executor", "ExecResult"]

--- a/core/execution/executor.py
+++ b/core/execution/executor.py
@@ -1,12 +1,54 @@
+import time
+
 from core.exchange.base import Exchange
 from core.data.logger import logger
+from core.execution.result import ExecResult
+from core.execution.utils import suppress_exc
+
 
 class Executor:
-    """Simple trade executor."""
+    """Simple trade executor handling multi-leg IOC orders."""
 
-    def __init__(self, exchange: Exchange):
+    def __init__(self, exchange: Exchange, max_latency_ms: float = 250.0):
         self.exchange = exchange
+        self.max_latency_ms = max_latency_ms
 
-    def execute(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
-        logger.info(f"execute_order symbol={symbol} side={side} qty={quantity} price={price}")
-        return self.exchange.place_order(symbol, side, quantity, price)
+    def execute(self, leg1: dict, leg2: dict | None = None) -> ExecResult:
+        start = time.perf_counter()
+        try:
+            logger.info(
+                f"leg1 symbol={leg1['symbol']} side={leg1['side']} qty={leg1['quantity']} price={leg1.get('price')}"
+            )
+            details1 = self.exchange.place_order(**leg1)
+        except Exception as exc:
+            logger.exception("leg1 order failed")
+            latency = (time.perf_counter() - start) * 1000
+            return ExecResult(False, f"leg1 error: {exc}", latency_ms=latency)
+
+        details = {"leg1": details1}
+        if leg2 is not None:
+            try:
+                logger.info(
+                    f"leg2 symbol={leg2['symbol']} side={leg2['side']} qty={leg2['quantity']} price={leg2.get('price')}"
+                )
+                details2 = self.exchange.place_order(**leg2)
+                details["leg2"] = details2
+            except Exception as exc:
+                logger.exception("leg2 order failed")
+                with suppress_exc():
+                    rollback_side = "SELL" if leg1["side"].upper() == "BUY" else "BUY"
+                    self.exchange.place_order(
+                        symbol=leg1["symbol"],
+                        side=rollback_side,
+                        quantity=leg1["quantity"],
+                        price=leg1.get("price"),
+                    )
+                latency = (time.perf_counter() - start) * 1000
+                return ExecResult(False, f"leg2 error: {exc}", details, latency)
+
+        latency = (time.perf_counter() - start) * 1000
+        if latency > self.max_latency_ms:
+            logger.warning(
+                f"latency {latency:.2f}ms exceeds {self.max_latency_ms}ms"
+            )
+        return ExecResult(True, "ok", details, latency)

--- a/core/execution/result.py
+++ b/core/execution/result.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class ExecResult:
+    """Execution result for IOC orders."""
+
+    ok: bool
+    reason: str
+    details: Dict[str, Any] = field(default_factory=dict)
+    latency_ms: float = 0.0

--- a/core/execution/utils.py
+++ b/core/execution/utils.py
@@ -1,0 +1,11 @@
+from contextlib import contextmanager
+from core.data.logger import logger
+
+
+@contextmanager
+def suppress_exc():
+    """Suppress and log exceptions during cleanup."""
+    try:
+        yield
+    except Exception:
+        logger.exception("rollback failure")

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,5 +1,6 @@
 from core.risk.manager import RiskManager
 from core.execution.executor import Executor
+from core.execution.result import ExecResult
 from core.exchange.base import Exchange
 
 class Pipeline:
@@ -9,9 +10,23 @@ class Pipeline:
         self.risk = RiskManager()
         self.executor = Executor(exchange)
 
-    def run(self, opportunity: dict):
+    def run(self, opportunity: dict) -> ExecResult:
         if not self.risk.check(opportunity):
-            return {"status": "rejected"}
-        return self.executor.execute(
-            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
-        )
+            return ExecResult(ok=False, reason="rejected")
+
+        leg1 = {
+            "symbol": opportunity["symbol"],
+            "side": opportunity["side"],
+            "quantity": opportunity["qty"],
+            "price": opportunity.get("price"),
+        }
+        leg2_data = opportunity.get("leg2")
+        leg2 = None
+        if leg2_data:
+            leg2 = {
+                "symbol": leg2_data["symbol"],
+                "side": leg2_data["side"],
+                "quantity": leg2_data["qty"],
+                "price": leg2_data.get("price"),
+            }
+        return self.executor.execute(leg1, leg2)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,5 +15,35 @@ def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
-    assert result["status"] == "filled"
+    assert result.ok
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+class FailingExchange(Exchange):
+    def __init__(self):
+        self.calls = 0
+        self.orders = []
+
+    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.calls += 1
+        if self.calls == 2:
+            raise RuntimeError("leg2 failure")
+        self.orders.append((symbol, side, quantity, price))
+        return {"status": "filled"}
+
+
+def test_leg2_failure_rolls_back_leg1():
+    exchange = FailingExchange()
+    pipe = Pipeline(exchange)
+    opportunity = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "qty": 1,
+        "leg2": {"symbol": "ETHUSDT", "side": "SELL", "qty": 1},
+    }
+    result = pipe.run(opportunity)
+    assert not result.ok
+    assert exchange.orders == [
+        ("BTCUSDT", "BUY", 1, None),
+        ("BTCUSDT", "SELL", 1, None),
+    ]


### PR DESCRIPTION
## Summary
- add ExecResult dataclass and suppress_exc context manager
- handle multi-leg IOC execution with rollback and latency warnings
- update pipeline and tests to use typed results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc422a6c0832cab4749da46931da1