### PR TITLE
feat: add configurable risk manager

### DIFF
--- a/core/risk/manager.py
+++ b/core/risk/manager.py
@@ -1,6 +1,72 @@
-class RiskManager:
-    """Very small placeholder risk manager."""
+from __future__ import annotations
 
-    def check(self, opportunity: dict) -> bool:
-        """Approve trade if quantity is positive."""
-        return opportunity.get("qty", 0) > 0
+from dataclasses import dataclass
+from typing import Dict, Tuple, Union
+
+from core.data.logger import logger
+
+
+@dataclass
+class RiskCfg:
+    """Configuration for :class:`RiskManager`. Limits are denominated in USD."""
+
+    trade_limit_usd: float = float("inf")
+    """Maximum notional allowed per trade."""
+
+    symbol_limit_usd: float = float("inf")
+    """Maximum aggregated exposure allowed per symbol."""
+
+    exchange_limit_usd: float = float("inf")
+    """Maximum aggregated exposure allowed per exchange."""
+
+
+class RiskManager:
+    """Simple risk manager supporting basic notional checks."""
+
+    TRADE_LIMIT = "TRADE_LIMIT"
+    SYMBOL_LIMIT = "SYMBOL_LIMIT"
+    EXCHANGE_LIMIT = "EXCHANGE_LIMIT"
+
+    def __init__(self, cfg: Union[RiskCfg, Dict] | None = None):
+        if cfg is None:
+            cfg = RiskCfg()
+        elif isinstance(cfg, dict):
+            cfg = RiskCfg(**cfg)
+        self.cfg = cfg
+
+    def check(
+        self,
+        symbol: str,
+        notional_usd: float,
+        sym_exposure_usd: float,
+        ex_exposure_usd: float,
+    ) -> Tuple[bool, str | None]:
+        """Validate order against configured limits.
+
+        Returns a tuple of ``(approved, reason)`` where ``reason`` is ``None`` when
+        the trade is approved or one of ``TRADE_LIMIT``, ``SYMBOL_LIMIT`` or
+        ``EXCHANGE_LIMIT`` when rejected.
+        """
+
+        if notional_usd > self.cfg.trade_limit_usd:
+            reason = self.TRADE_LIMIT
+            logger.info(
+                f"risk_reject symbol={symbol} reason={reason} notional={notional_usd}"
+            )
+            return False, reason
+
+        if sym_exposure_usd + notional_usd > self.cfg.symbol_limit_usd:
+            reason = self.SYMBOL_LIMIT
+            logger.info(
+                f"risk_reject symbol={symbol} reason={reason} sym_exp={sym_exposure_usd} notional={notional_usd}"
+            )
+            return False, reason
+
+        if ex_exposure_usd + notional_usd > self.cfg.exchange_limit_usd:
+            reason = self.EXCHANGE_LIMIT
+            logger.info(
+                f"risk_reject symbol={symbol} reason={reason} ex_exp={ex_exposure_usd} notional={notional_usd}"
+            )
+            return False, reason
+
+        return True, None

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,17 +1,24 @@
-from core.risk.manager import RiskManager
+from core.risk.manager import RiskCfg, RiskManager
 from core.execution.executor import Executor
 from core.exchange.base import Exchange
 
 class Pipeline:
     """End-to-end trading pipeline."""
 
-    def __init__(self, exchange: Exchange):
-        self.risk = RiskManager()
+    def __init__(self, exchange: Exchange, risk_cfg: RiskCfg | dict | None = None):
+        self.risk = RiskManager(risk_cfg)
         self.executor = Executor(exchange)
 
-    def run(self, opportunity: dict):
-        if not self.risk.check(opportunity):
-            return {"status": "rejected"}
+    def run(self, opportunity: dict, sym_exposure_usd: float, ex_exposure_usd: float):
+        notional = opportunity.get("notional_usd")
+        if notional is None:
+            price = opportunity.get("price", 0)
+            notional = opportunity.get("qty", 0) * price
+        approved, reason = self.risk.check(
+            opportunity["symbol"], notional, sym_exposure_usd, ex_exposure_usd
+        )
+        if not approved:
+            return {"status": "rejected", "reason": reason}
         return self.executor.execute(
             opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,14 +6,34 @@ class DummyExchange(Exchange):
     def __init__(self):
         self.orders = []
 
-    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+    def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
         self.orders.append((symbol, side, quantity, price))
         return {"status": "filled"}
 
 
 def test_pipeline_executes_order():
     exchange = DummyExchange()
-    pipe = Pipeline(exchange)
-    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    pipe = Pipeline(
+        exchange,
+        {"trade_limit_usd": 1000, "symbol_limit_usd": 2000, "exchange_limit_usd": 5000},
+    )
+    result = pipe.run(
+        {"symbol": "BTCUSDT", "side": "BUY", "qty": 1, "price": 500}, 0, 0
+    )
     assert result["status"] == "filled"
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_rejects_over_limit():
+    exchange = DummyExchange()
+    pipe = Pipeline(
+        exchange,
+        {"trade_limit_usd": 100, "symbol_limit_usd": 200, "exchange_limit_usd": 500},
+    )
+    result = pipe.run(
+        {"symbol": "ETHUSDT", "side": "BUY", "qty": 1, "price": 150}, 0, 0
+    )
+    assert result["status"] == "rejected"
+    assert result["reason"] == "TRADE_LIMIT"


### PR DESCRIPTION
## Summary
- replace placeholder risk manager with configurable `RiskCfg`
- expose detailed rejection reasons and log them
- plumb risk checks through pipeline and add coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc42d4274832c88e5b74a8c518a6e