### PR TITLE
Introduce PipelineResult and event logging

### DIFF
--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,6 +1,19 @@
+from dataclasses import dataclass
+from time import perf_counter
+
 from core.risk.manager import RiskManager
 from core.execution.executor import Executor
 from core.exchange.base import Exchange
+from core.data.logger import logger
+
+
+@dataclass
+class PipelineResult:
+    """Result container for pipeline operations."""
+
+    accepted: bool
+    reason: str
+    exec: dict | None = None
 
 class Pipeline:
     """End-to-end trading pipeline."""
@@ -9,9 +22,24 @@ class Pipeline:
         self.risk = RiskManager()
         self.executor = Executor(exchange)
 
-    def run(self, opportunity: dict):
+    def run(self, opportunity: dict) -> PipelineResult:
+        start = perf_counter()
+        symbol = opportunity.get("symbol", "")
+
         if not self.risk.check(opportunity):
-            return {"status": "rejected"}
-        return self.executor.execute(
-            opportunity["symbol"], opportunity["side"], opportunity["qty"], opportunity.get("price")
-        )
+            latency = perf_counter() - start
+            logger.info(f"rejected symbol={symbol} latency={latency:.6f}")
+            return PipelineResult(False, "rejected")
+
+        try:
+            exec_details = self.executor.execute(
+                opportunity["symbol"],
+                opportunity["side"],
+                opportunity["qty"],
+                opportunity.get("price"),
+            )
+            return PipelineResult(True, "accepted", exec_details)
+        except Exception:
+            latency = perf_counter() - start
+            logger.error(f"exec_fail symbol={symbol} latency={latency:.6f}")
+            return PipelineResult(False, "exec_fail")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from orchestrator.pipeline import Pipeline
+from orchestrator.pipeline import Pipeline, PipelineResult
 from core.exchange.base import Exchange
 
 
@@ -15,5 +15,34 @@ def test_pipeline_executes_order():
     exchange = DummyExchange()
     pipe = Pipeline(exchange)
     result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
-    assert result["status"] == "filled"
+    assert isinstance(result, PipelineResult)
+    assert result.accepted is True
+    assert result.reason == "accepted"
+    assert result.exec["status"] == "filled"
     assert exchange.orders[0][0] == "BTCUSDT"
+
+
+def test_pipeline_rejects_order():
+    exchange = DummyExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 0})
+    assert isinstance(result, PipelineResult)
+    assert result.accepted is False
+    assert result.reason == "rejected"
+    assert result.exec is None
+    assert exchange.orders == []
+
+
+class FailingExchange(Exchange):
+    def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        raise RuntimeError("boom")
+
+
+def test_pipeline_exec_fail():
+    exchange = FailingExchange()
+    pipe = Pipeline(exchange)
+    result = pipe.run({"symbol": "BTCUSDT", "side": "BUY", "qty": 1})
+    assert isinstance(result, PipelineResult)
+    assert result.accepted is False
+    assert result.reason == "exec_fail"
+    assert result.exec is None


### PR DESCRIPTION
## Summary
- add PipelineResult dataclass encapsulating acceptance, reason, and execution details
- log rejected and exec_fail events with symbol and latency
- expand tests for success, rejection, and execution failure cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc4367ec8832c8610b6f5f10c0c78