### PR TITLE
Add tests for logger singleton and risk manager

### DIFF
--- a/tests/test_logging_singleton.py
+++ b/tests/test_logging_singleton.py
@@ -1,0 +1,11 @@
+import logging
+from logging import getLogger as get_logger
+
+def test_logging_singleton_identity_and_handler():
+    logger1 = get_logger("x")
+    logger1.handlers.clear()
+    handler = logging.StreamHandler()
+    logger1.addHandler(handler)
+    logger2 = get_logger("x")
+    assert logger1 is logger2
+    assert len(logger2.handlers) == 1

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,9 @@
+from core.risk.manager import RiskManager
+
+
+def test_risk_manager_accepts_positive_qty_and_rejects_non_positive():
+    sample_config = {"max_qty": 100}
+    rm = RiskManager()
+    assert rm.check({"qty": 5}) is True
+    assert rm.check({"qty": 0}) is False
+    assert rm.check({"qty": -10}) is False


### PR DESCRIPTION
## Summary
- add logging singleton test to ensure consistent logger and single handler
- validate RiskManager accepts positive quantities and rejects non-positive ones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc4610b0c832c987fee3ac9008d3a